### PR TITLE
Add missing runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ git submodule update --init
 ### Install dependencies
 
 ~~~
-sudo apt install python3-iniparse cmake cython libv4l-dev
+sudo apt install cython libv4l-dev python3-numpy python3-serial python3-lxml python3-picamera
+sudo pip3 install pymavlink
 ~~~
 
 Install wifibroadcast_bridge from here: https://github.com/webbbn/wifibroadcast_bridge


### PR DESCRIPTION
I've found more missing Python 3 dependencies.

PS: It's better to generate `requirements.txt` and use `pip3 install -r requirements.txt` to install Python 3 depenencies.